### PR TITLE
modified the test/example so that it is 'all in one python file'

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -3,9 +3,12 @@
 
 - No-ACK example
 
-% python test_newschc.py --data-file test/icmpv6.dmp
+% python3 test_newschc.py --data-file test/icmpv6.dmp
 
 - ACK-on-Error example
 
-% python test_newschc.py --context example/context-100.json --rule-comp example/comp-rule-100.json --rule-fragin example/frag-rule-101.json --rule-fragout example/frag-rule-102.json --data-file test/icmpv6.dmp --loss-mode list --loss-param 1,2
+% python3 test_newschc.py --context example/context-100.json --rule-comp example/comp-rule-100.json --rule-fragin example/frag-rule-101.json --rule-fragout example/frag-rule-102.json --data-file test/icmpv6.dmp --loss-mode list --loss-param 1,2
 
+- Same example, but with everything in one file:
+
+% python3 test_frag.py

--- a/src/test_frag.py
+++ b/src/test_frag.py
@@ -1,0 +1,108 @@
+#---------------------------------------------------------------------------
+
+from base_import import *  # used for now for differing modules in py/upy
+
+import schc
+import simsched
+import simlayer2
+import simul
+from rulemanager import RuleManager
+
+#---------------------------------------------------------------------------
+
+l2_mtu = 56
+data_size = 14
+
+rule_context = {
+    "devL2Addr": "*",
+    "dstIID": "*"
+}
+
+compress_rule = {
+    "ruleLength": 3,
+    "ruleID": 5,
+    "compression": {
+        "rule_set": []
+    }
+}
+
+frag_rule1 = {
+    "ruleLength": 6,
+    "ruleID": 1,
+    "profile": { "L2WordSize": 8 },
+    "fragmentation": {
+        "FRMode": "ackOnError",
+        "FRModeProfile": {
+            "dtagSize": 2,
+            "WSize": 5,
+            "FCNSize": 3,
+            "ackBehavior": "afterAll1",
+            "tileSize": 9,
+            "MICAlgorithm": "crc32",
+            "MICWordSize": 8
+        }
+    }
+}
+
+frag_rule2 = {
+    "ruleLength": 6,
+    "ruleID": 2,
+    "profile": { "L2WordSize": 8 },
+    "fragmentation": {
+        "FRMode": "ackOnError",
+        "FRModeProfile": {
+            "dtagSize": 2,
+            "WSize": 5,
+            "FCNSize": 3,
+            "ackBehavior": "afterAll1",
+            "tileSize": 9,
+            "MICAlgorithm": "crc32",
+            "MICWordSize": 8
+        }
+    }
+}
+
+#---------------------------------------------------------------------------
+
+def make_node(sim, rule_manager, devaddr=None, extra_config={}):
+    node = simul.SimulSCHCNode(sim, extra_config)
+    node.protocol.set_rulemanager(rule_manager)
+    if devaddr is None:
+        devaddr = node.id
+    node.protocol.set_dev_L2addr(devaddr)
+    return node
+
+#---------------------------------------------------------------------------
+
+rm0 = RuleManager()
+rm0.add_context(rule_context, compress_rule, frag_rule1, frag_rule2)
+
+rm1 = RuleManager()
+rm1.add_context(rule_context, compress_rule, frag_rule1, frag_rule2)
+
+#--------------------------------------------------
+
+simul_config = {
+    "log": True,
+}
+sim = simul.Simul(simul_config)
+
+node0 = make_node(sim, rm0)                   # SCHC device
+node1 = make_node(sim, rm1, devaddr=node0.id) # SCHC gw
+sim.add_sym_link(node0, node1)
+node0.layer2.set_mtu(l2_mtu)
+node1.layer2.set_mtu(l2_mtu)
+
+print("SCHC device L3={} L2={} RM={}".format(node0.layer3.L3addr, node0.id,
+                                             rm0.__dict__))
+print("SCHC gw     L3={} L2={} RM={}".format(node1.layer3.L3addr, node1.id,
+                                             rm1.__dict__))
+
+#--------------------------------------------------
+
+payload = bytearray(range(1, 1+data_size))
+node0.protocol.layer3.send_later(1, node1.layer3.L3addr, payload)
+
+sim.run()
+
+#---------------------------------------------------------------------------


### PR DESCRIPTION
The example has currently a long command line, and features several configuration files.

It has been copied and then modified (embedded configuration into python file instead of json configuration file, no losses, no compression, etc.) so that it fits entirely in one file with no option necessary on the command line.