### PR TITLE
tests: auto discover tests (first attempt)

### DIFF
--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -3,9 +3,10 @@ ifeq ($(PY),)
 	PY := micropython
 endif
 
+TESTS := $(basename $(wildcard test_*.py))
+TESTBASE := __testbase__
+
 all-tests:
-	$(PY) test_bitarray.py
-	$(PY) test_bitarray2.py
-	$(PY) test_bitmap.py
-	$(PY) test_ruleman.py
-	$(PY) test_simsched.py
+	@for i in $(TESTS) ; do \
+		(cat $$i.py;cat $(TESTBASE).py) | $(PY) ; \
+	done

--- a/src/tests/__testbase__.py
+++ b/src/tests/__testbase__.py
@@ -1,0 +1,6 @@
+_l=[f for f in locals() if str(f).startswith("test_")]
+
+for l in _l:
+    f = locals()[l]
+    f()
+

--- a/src/tests/test_bitarray.py
+++ b/src/tests/test_bitarray.py
@@ -73,9 +73,3 @@ def test_check_newbitbuffer_consistency():
         print (bits, nb_bits, bits2)
         assert bits == bits2  # XXX: raise exception
 #    assert len(bitbuffer2.get_content()) == 0  # XXX: raise exception
-
-
-# for micropython and other tester.
-if __name__ == "__main__":
-    test_bitbuffer_consistency()
-    test_check_newbitbuffer_consistency()

--- a/src/tests/test_bitarray2.py
+++ b/src/tests/test_bitarray2.py
@@ -172,8 +172,3 @@ def test_bitarray2():
     a.add_bytes(bytearray([3,4]))
     print(a)
     assert str(a) == r"b'\x50\x30\x40'/20"
-
-
-# for micropython and other tester.
-if __name__ == "__main__":
-    test_bitarray2()

--- a/src/tests/test_bitmap.py
+++ b/src/tests/test_bitmap.py
@@ -166,11 +166,3 @@ def test_fragment_bitmap_04():
         (2, BitBuffer([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, 0, 0, 1]))]
     check_bitmaps(bitmaps, expected)
-
-
-# for micropython and other tester.
-if __name__ == "__main__":
-    test_fragment_bitmap_01()
-    test_fragment_bitmap_02()
-    test_fragment_bitmap_03()
-    test_fragment_bitmap_04()

--- a/src/tests/test_ruleman.py
+++ b/src/tests/test_ruleman.py
@@ -72,8 +72,3 @@ def test_ruleman_01():
     print(RM.find_context_bydevL2addr("AABBCCDD"))
     print(RM.find_context_bydstiid("2001:0db8:85a3::beef"))
     RM.find_rule_bypacket(context1, BitBuffer(int("10000111",2).to_bytes(1, "big")))
-
-
-# for micropython and other tester.
-if __name__ == "__main__":
-    test_ruleman_01()

--- a/src/tests/test_simsched.py
+++ b/src/tests/test_simsched.py
@@ -26,7 +26,3 @@ def test_simsched_01():
     scheduler.add_event(3, callback, ("4", "four"))
     scheduler.add_event(1, callback, ("1", "one"))
     scheduler.run()
-
-# for micropython and other tester.
-if __name__ == "__main__":
-    test_simsched_01()


### PR DESCRIPTION
This PR is adds an auto discover mechanism for tests when using other environment than pytest (e.g micropython).

Tests will be auto discovered if they follow the same rules as the current configuration of pytest:
- Included inside a `test_*.py` file
- Function name has `test_` prefix

`make all-tests` with and without this PR should give a similar output.

Since this script will call function tests without any argument, [it's not yet possible to inject fixtures](https://docs.pytest.org/en/latest/fixture.html). I will check if there's a workaround