### PR TITLE
UDP example - transmit_callback defautl to None

### DIFF
--- a/examples/udp/net_udp_core.py
+++ b/examples/udp/net_udp_core.py
@@ -68,7 +68,7 @@ class UdpLowerLayer:
         self.protocol = protocol
         self._actual_init()
 
-    def send_packet(self, packet, dst_str_address, transmit_callback):
+    def send_packet(self, packet, dst_str_address, transmit_callback=None):
         if dst_str_address is None or dst_str_address == "*":
             dst_address = self.udp_dst
         else:


### PR DESCRIPTION
From time to time `send_packet` is called without any `transmit_callback`, moreover `architecture.py` defines a default value to `None` too