### PR TITLE
Use comressor to amend no-compression rule to uncompressed packet

### DIFF
--- a/src/protocol.py
+++ b/src/protocol.py
@@ -184,8 +184,8 @@ class SCHCProtocol:
 
         if rule["Compression"] == []:  # XXX: should be "NoCompression"
             self._log("compression result no-compression")
-            return BitBuffer(raw_packet)
-
+            # the whole packet will be the compression residue
+            residue = raw_packet
         schc_packet = self.compressor.compress(rule, parsed_packet, residue, t_dir)
         dprint(schc_packet)
         schc_packet.display("bin")


### PR DESCRIPTION
Following further testing with #108 on top, it also seems that uncompressed packets sent are malformed (the rule in the beginning is missing). Instead of having dedicated code for this (create an empty BitBuffer, add rule, add content) we just use the raw packet as residue for compression, which, since the compression rule is empty, results in the raw packet appended with the no-compression rule id.

However, now that I added this code, I am not sure I understood the SCHC RFC correctly... Is there no rule ID to the packet if the packet is uncomressed? If so, how does the receiver then know, that the packet is uncompressed?