### PR TITLE
protocol: fix schc_recv return when no rule is found

### DIFF
--- a/src/protocol.py
+++ b/src/protocol.py
@@ -347,7 +347,7 @@ class SCHCProtocol:
 
         if rule == None:
             print ("No rule found")
-            return None
+            return None, None
 
         if T_COMP in rule:
             if self.position == T_POSITION_DEVICE:


### PR DESCRIPTION
In any other case but the case when a rule is not found, `schc_recv` returns a tuple consisting of the device ID and the data. If there is no rule, it returns just `None`. This inconsistency makes it really annoying to handle the case, when there is no rule found, so just make it more consistent (but really, I guess it would be better to just raise an exception in that case, since clearly something went wrong here).